### PR TITLE
Open channel from conversation menu

### DIFF
--- a/renderer/features/channels/OpenChannelModal.js
+++ b/renderer/features/channels/OpenChannelModal.js
@@ -4,24 +4,23 @@ import PropTypes from 'prop-types';
 import Modal from '../common/Modal';
 import OpenChannelForm from './OpenChannelForm';
 import { fetchChannels, hideOpenChannelModal } from './channelsSlice';
-import { nodeType, nodeDetailsType } from '../../types';
 
 const OpenChannelModal = props => {
   const {
-    openChannelWithNode,
+    openChannelWithPubkey,
     openChannelModalVisible,
     hideOpenChannelModal,
     fetchChannels
   } = props;
 
-  // Without explicitly casting openChannelWithNode, isOpen might be Object
-  const isOpen = openChannelModalVisible && !!openChannelWithNode;
+  // Without explicitly casting openChannelWithPubkey, isOpen might be object
+  const isOpen = openChannelModalVisible && !!openChannelWithPubkey;
 
   return (
     <Modal isOpen={isOpen} onClose={hideOpenChannelModal}>
       {isOpen && (
         <OpenChannelForm
-          node={openChannelWithNode}
+          pubkey={openChannelWithPubkey}
           onSuccess={() => {
             fetchChannels();
             hideOpenChannelModal();
@@ -35,18 +34,19 @@ const OpenChannelModal = props => {
 OpenChannelModal.propTypes = {
   hideOpenChannelModal: PropTypes.func.isRequired,
   fetchChannels: PropTypes.func.isRequired,
-  openChannelWithNode: PropTypes.oneOfType([nodeType, nodeDetailsType]),
+  openChannelWithPubkey: PropTypes.string,
   openChannelModalVisible: PropTypes.bool.isRequired
 };
+
 OpenChannelModal.defaultProps = {
-  openChannelWithNode: null
+  openChannelWithPubkey: null
 };
 
 const mapStateToProps = state => {
-  const { openChannelModalVisible, openChannelWithNode } = state.channels;
+  const { openChannelModalVisible, openChannelWithPubkey } = state.channels;
   return {
     openChannelModalVisible,
-    openChannelWithNode
+    openChannelWithPubkey
   };
 };
 

--- a/renderer/features/channels/OpenChannelModal.js
+++ b/renderer/features/channels/OpenChannelModal.js
@@ -14,7 +14,8 @@ const OpenChannelModal = props => {
     fetchChannels
   } = props;
 
-  const isOpen = openChannelModalVisible && openChannelWithNode;
+  // Without explicitly casting openChannelWithNode, isOpen might be Object
+  const isOpen = openChannelModalVisible && !!openChannelWithNode;
 
   return (
     <Modal isOpen={isOpen} onClose={hideOpenChannelModal}>

--- a/renderer/features/channels/channelsSlice.js
+++ b/renderer/features/channels/channelsSlice.js
@@ -10,7 +10,7 @@ const channelsSlice = createSlice({
     closingChannels: [],
     loading: false,
     openChannelModalVisible: false,
-    openChannelWithNode: null,
+    openChannelWithPubkey: null,
     manageChannelsModalVisible: false,
     error: null
   },
@@ -21,7 +21,7 @@ const channelsSlice = createSlice({
       state.closingChannels = [];
       state.openChannelModalVisible = false;
       state.manageChannelsModalVisible = false;
-      state.openChannelWithNode = null;
+      state.openChannelWithPubkey = null;
       state.loading = false;
       state.error = null;
     }
@@ -43,9 +43,9 @@ const channelsSlice = createSlice({
       state.error = error;
     },
     showOpenChannelModal: (state, action) => {
-      const { node } = action.payload;
+      const { pubkey } = action.payload;
       state.openChannelModalVisible = true;
-      state.openChannelWithNode = node;
+      state.openChannelWithPubkey = pubkey;
     },
     hideOpenChannelModal: state => {
       state.openChannelModalVisible = false;

--- a/renderer/features/conversations/Conversation.js
+++ b/renderer/features/conversations/Conversation.js
@@ -164,6 +164,7 @@ const Conversation = props => {
         id={id}
         color={color}
         displayName={displayName}
+        pubkey={withPubkey}
         balance={balance}
         feeLimitMSats={feeLimitMSats}
       />

--- a/renderer/features/conversations/ConversationDetail.js
+++ b/renderer/features/conversations/ConversationDetail.js
@@ -22,7 +22,7 @@ const ConversationDetail = props => {
             label="Open Channel"
             outlined
             onClick={() => {
-              dispatch(showOpenChannelModal({ node: conversationDetails }));
+              dispatch(showOpenChannelModal({ pubkey: pubKey }));
             }}
           />
         </div>

--- a/renderer/features/conversations/ConversationHeader.js
+++ b/renderer/features/conversations/ConversationHeader.js
@@ -17,6 +17,8 @@ import { updateConversationFeeLimit } from '../../../utils/db';
 import { queue } from '../../dialogQueue';
 import FeeLimitIcon from '../images/icons/FeeLimitIcon';
 import DeleteConversationIcon from '../images/icons/DeleteConversationIcon';
+import NewChannelIcon from '../images/icons/NewChannelIcon';
+import { showOpenChannelModal } from '../channels/channelsSlice';
 
 const validFeeLimit = feeLimitMSats => {
   const intVal = parseInt(feeLimitMSats, 10);
@@ -30,7 +32,7 @@ const ConversationHeader = props => {
   const [open, setOpen] = React.useState(false);
   const dispatch = useDispatch();
 
-  const { id, color, displayName, feeLimitMSats } = props;
+  const { id, color, displayName, feeLimitMSats, pubkey } = props;
   return (
     <div className="conversationHeader">
       <span>
@@ -107,6 +109,12 @@ const ConversationHeader = props => {
               <ListItemGraphic icon={<DeleteConversationIcon />} />
               Delete Conversation
             </MenuItem>
+            <MenuItem
+              onClick={() => dispatch(showOpenChannelModal({ pubkey }))}
+            >
+              <ListItemGraphic icon={<NewChannelIcon />} />
+              Open Channel
+            </MenuItem>
           </Menu>
           <IconButton
             className="conversation-header-more-icon"
@@ -126,7 +134,8 @@ ConversationHeader.propTypes = {
   id: PropTypes.number.isRequired,
   color: PropTypes.string.isRequired,
   displayName: PropTypes.string.isRequired,
-  feeLimitMSats: PropTypes.number.isRequired
+  feeLimitMSats: PropTypes.number.isRequired,
+  pubkey: PropTypes.string.isRequired
 };
 
 export default ConversationHeader;

--- a/renderer/features/nodes/NodeListItem.js
+++ b/renderer/features/nodes/NodeListItem.js
@@ -58,7 +58,6 @@ const NodeListItem = ({ node, ctaText, ctaClicked }) => {
 
 NodeListItem.propTypes = {
   node: nodeType.isRequired,
-  pubKey: PropTypes.string.isRequired,
   ctaText: PropTypes.string.isRequired,
   ctaClicked: PropTypes.func.isRequired
 };

--- a/renderer/features/nodes/NodeListPage.js
+++ b/renderer/features/nodes/NodeListPage.js
@@ -18,7 +18,7 @@ const NodeListPage = () => {
       <FilteredNodeList
         ctaText="Open"
         ctaClicked={node => {
-          dispatch(showOpenChannelModal({ node }));
+          dispatch(showOpenChannelModal({ pubkey: node.pubKey }));
         }}
       />
     </Page>

--- a/renderer/features/onboarding/Connect.js
+++ b/renderer/features/onboarding/Connect.js
@@ -19,7 +19,7 @@ const Connect = () => {
       <FilteredNodeList
         ctaText="Connect"
         ctaClicked={node => {
-          dispatch(showOpenChannelModal({ node }));
+          dispatch(showOpenChannelModal({ pubkey: node.pubKey }));
         }}
       />
     </Page>

--- a/services/lnd/grpc.js
+++ b/services/lnd/grpc.js
@@ -909,19 +909,14 @@ class LndGrpcWrapper extends EventEmitter {
     pubkey,
     localSatoshis,
     remoteSatoshis,
-    targetConfirmations,
-    isPrivate,
-    host
+    targetConfirmations
   }) {
     try {
-      await this.grpc.services.Lightning.connectAndOpen({
-        pubkey,
-        host,
-        localSatoshis,
-        remoteSatoshis,
-        targetConfirmations,
-        isPrivate,
-        spendUnconfirmed: false
+      await this.grpc.services.Lightning.openChannel({
+        node_pubkey: Buffer.from(pubkey, 'hex'),
+        local_funding_amount: localSatoshis + remoteSatoshis,
+        push_sat: remoteSatoshis,
+        target_conf: targetConfirmations
       });
     } catch (e) {
       grpcLog.info('failed to open channel');


### PR DESCRIPTION
I did some refactoring so that the OpenChannelModal needs the pubkey in the props instead of the node. I think it makes sense like this, because in order to open a new channel we actually just need the pubkey. In the previous version, the grpc client first connected to the node as a peer (which required the host) and then opened the channel, but this is not necessary, the channel can be opened without connecting first.

Then I just added an option to open a channel from the conversation menu.

Fixes: https://github.com/LN-Juggernaut/juggernaut-desktop/issues/15.

