### PR TITLE
Add support for LND 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -299,7 +299,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.12.0",
     "@hot-loader/react-dom": "^16.11.0",
-    "@ln-juggernaut/lnd-grpc": "0.3.5",
+    "@ln-juggernaut/lnd-grpc": "0.4.0-beta.10",
     "@reduxjs/toolkit": "^1.1.0",
     "bitcoinjs-lib": "^5.1.7",
     "bolt11": "^1.2.7",

--- a/services/lnd/grpc.js
+++ b/services/lnd/grpc.js
@@ -825,10 +825,14 @@ class LndGrpcWrapper extends EventEmitter {
 
         if (data.state && data.state !== 'IN_FLIGHT') {
           if (data.state === 'SUCCEEDED') {
+            const feeAmountMSats = data.htlcs.reduce((totalFeesMSats, htlc) => {
+              return totalFeesMSats + htlc.route.total_fees_msat;
+            }, 0);
+
             resolve({
               amountMSats: amountToSend,
-              feeAmountMSats: data.route.total_fees_msat,
-              preimage: preimageBytes.toString('hex')
+              preimage: preimageBytes.toString('hex'),
+              feeAmountMSats
             });
           } else {
             const paymentState = data.state;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,20 +1228,21 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@ln-juggernaut/lnd-grpc@0.3.5":
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/@ln-juggernaut/lnd-grpc/-/lnd-grpc-0.3.5.tgz#479159d39a936b66d48b37eb3bf9edc571be8961"
-  integrity sha512-wUAfdpxNJAbx9lL73LMzBugpycsBj6yGTbfIJnNU+j6AVNW68fgvUDT7WF8SWBGkPsvvs2UZS6/82ELGC2nb+A==
+"@ln-juggernaut/lnd-grpc@0.4.0-beta.10":
+  version "0.4.0-beta.10"
+  resolved "https://registry.yarnpkg.com/@ln-juggernaut/lnd-grpc/-/lnd-grpc-0.4.0-beta.10.tgz#52ec0d2427b00461aaf93197e40f99bc428fd664"
+  integrity sha512-RPsVrZvvf7GE3BtYx/IzOD0Vdfn3B/1TDamQ5iBFSJiV2+Yoxf8j9a7ZifGHnajUJEH0+h0NEL6pTK04GoKQXQ==
   dependencies:
     "@grpc/grpc-js" "0.5.2"
     "@ln-juggernaut/proto-loader" "0.5.3"
     debug "4.1.1"
+    get-port "5.1.1"
     javascript-state-machine "3.1.0"
     lndconnect "0.2.10"
     lodash.defaultsdeep "4.6.1"
-    semver "6.3.0"
+    semver "^7.1.3"
     untildify "4.0.0"
-    validator "11.1.0"
+    validator "^13.0.0"
 
 "@ln-juggernaut/proto-loader@0.5.3":
   version "0.5.3"
@@ -8003,6 +8004,11 @@ get-own-enumerable-property-symbols@^3.0.0:
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
   integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
 
+get-port@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
+  integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -13981,15 +13987,15 @@ semver@5.5.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
   integrity sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==
 
-semver@6.3.0, semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
 semver@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
+
+semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.1.2, semver@^7.1.3:
   version "7.1.3"
@@ -15905,10 +15911,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validator@11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-11.1.0.tgz#ac18cac42e0aa5902b603d7a5d9b7827e2346ac4"
-  integrity sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg==
+validator@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.0.0.tgz#0fb6c6bb5218ea23d368a8347e6d0f5a70e3bcab"
+  integrity sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA==
 
 value-equal@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Other than updating the protos used the only real change needed is how we calculate fees.  Previously we were able to get the fees for the whole route on the parent payment data object but now we have to loop over each HTLC and sum it up. 

Luckily this also works on 0.9.0 so can use one approach for both versions.

Handles https://github.com/LN-Juggernaut/juggernaut-desktop/issues/13