### PR TITLE
Fix LICENSE link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@
 
 ## License
 
-MIT © [Juggernaut](https://github.com/LN-Juggernaut/juggernaut-desktop/LICENSE)
+MIT © [Juggernaut](LICENSE)


### PR DESCRIPTION
The link doesn't work, I think this should fix it.

I also think we should have a link to the website in either the repo description or the README.md so that people who find the repo first can visit the website.